### PR TITLE
Remove redundant CSS definitions from chat widget styles

### DIFF
--- a/chatbot/Frontend/style.css
+++ b/chatbot/Frontend/style.css
@@ -310,10 +310,6 @@ main p {
   background: #006ad1;
 }
 
-#chat-input button:hover {
-  background: #006ad1;
-}
-
 /* Base style for messages */
 .message {
   padding: 12px 16px;
@@ -411,19 +407,4 @@ main p {
   100% { transform: scale(1); }
 }
 
-
-/* Mensagem do bot */
-.message.bot {
-  background: #e6f0ff;
-  color: #003366;
-  align-self: flex-start;
-  border-top-left-radius: 0;
-}
-
-/* Mensagem do usuário */
-.message.user {
-  background: #0080ff;
-  color: white;
-  align-self: flex-end;
-  border-top-right-radius: 0;
-}
+


### PR DESCRIPTION
## Summary
- remove the duplicate `#chat-input button:hover` declaration
- retain the initial `.message.bot` and `.message.user` styles by deleting later overrides

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c886efaf188332b96ced081ec7a9fd