### PR TITLE
Add jQuery CDN script to chatbot index page

### DIFF
--- a/chatbot/Frontend/index.html
+++ b/chatbot/Frontend/index.html
@@ -72,6 +72,7 @@
     <i class='bx bx-message-rounded-dots'></i>
   </div>
 
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
   <script>
   async function sendMessage() {
     const input = document.getElementById('chatInput');


### PR DESCRIPTION
## Summary
- add the jQuery 3.6.0 CDN script tag to the chatbot index page ahead of scripts that rely on it

## Testing
- not run (HTML change only)


------
https://chatgpt.com/codex/tasks/task_e_68c8898656ec8332bb668b67452ab161