### PR TITLE
Fix overlay background color property

### DIFF
--- a/chatbot/Frontend/style.css
+++ b/chatbot/Frontend/style.css
@@ -15,7 +15,7 @@
     }
   
     .overlay {
-      bbackground-color: rgba(0, 0, 0, 0.6);
+      background-color: rgba(0, 0, 0, 0.6);
       height: 100%;
       width: 100%;
       position: absolute;


### PR DESCRIPTION
## Summary
- correct the overlay style to use the proper background-color property name

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c8898795cc8332b70b3a9495ec0c1c